### PR TITLE
Only allow sender with "fluffymachines.admin" permission to execute /fm ai

### DIFF
--- a/src/main/java/io/ncbpfluffybear/fluffymachines/FluffyMachines.java
+++ b/src/main/java/io/ncbpfluffybear/fluffymachines/FluffyMachines.java
@@ -128,7 +128,7 @@ public class FluffyMachines extends JavaPlugin implements SlimefunAddon {
                 return true;
             }
 
-        } else if (args[0].equalsIgnoreCase("ai")
+        } else if (args[0].equalsIgnoreCase("ai") && sender.hasPermission("fluffymachines.admin")
             && sender instanceof Player) {
             Player p = (Player) sender;
 


### PR DESCRIPTION
## Short Description
<!-- Please explain what you changed/added and why you did it in detail. -->
Require the "fluffymachines.admin" permission to execute /fm ai. This prevents normal players from modifying block data which may lead to various exploitations.

## Additions/Changes/Removals
<!-- Please list all the changes you have made. -->
- Require the "fluffymachines.admin" permission to execute /fm ai

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->

## Video Proof
<!-- Attach video proof that what you added works -->
<!-- Avoid recording using a phone unless absolutely necessary -->
This is a single case scenario where a block data's id is changed into another id which changes the Slimefun item dropped when breaking. 

https://user-images.githubusercontent.com/13492360/103566239-a1e81a00-4efc-11eb-98a1-949cf88669e5.mp4



## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [X] I have fully tested the proposed changes and promise that they will not break everything into chaos.
- [ ] I have tested every variant of every item or config setting that I have added.
- [X] I have also tested the proposed changes in combination with base Slimefun and made sure nothing breaks/unexpected happens.
- [X] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added which may not be obvious to maintainers.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
